### PR TITLE
Fix/short list with alchemy

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -1511,7 +1511,7 @@ def RandomizeDominion(setNames=None, options=None):
             # If there are only 2 Alchemy cards, pull an additional Alchemy
             # card and randomly remove one non-Alchemy card
             alchemyCards.update(random.sample(Alchemy.cards - alchemyCards, 1))
-            resultSet = alchemyCards.union(random.sample(resultSet, 7))
+            resultSet = alchemyCards.union(random.sample(resultSet - alchemyCards, 7))
         # If there are 3 or more Alchemy cards, let it lie.
 
     # Young Witch support

--- a/randomizer.py
+++ b/randomizer.py
@@ -1510,8 +1510,9 @@ def RandomizeDominion(setNames=None, options=None):
         elif len(alchemyCards) == 2:
             # If there are only 2 Alchemy cards, pull an additional Alchemy
             # card and randomly remove one non-Alchemy card
+            resultSet -= alchemyCards
             alchemyCards.update(random.sample(Alchemy.cards - alchemyCards, 1))
-            resultSet = alchemyCards.union(random.sample(resultSet - alchemyCards, 7))
+            resultSet = alchemyCards.union(random.sample(resultSet, 7))
         # If there are 3 or more Alchemy cards, let it lie.
 
     # Young Witch support


### PR DESCRIPTION
There was a very rare, but possible bug with the alchemy rule enforcement.

We weren't making sure to not choose a card that we hadn't already picked, which could result in adding another copy of the same card (which would disappear because sets don't allow multiples).

We would then also grab 7 random cards from the result list, which could include a copy one of the existing alchemy cards (which would again disappear).

The Result would be a 8-9 card list contain 3 alchemy cards.